### PR TITLE
Dockerize ws rest server boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 		<module>integrations/appsensor-integration-jmx</module>
 		<module>integrations/appsensor-integration-cef-syslog</module>
 		<module>integrations/appsensor-integration-spring-security</module>
-		<module>integrations/appsensor-integration-influxdb</module>
+		<!-- <module>integrations/appsensor-integration-influxdb</module> -->
 	</modules>
 	
 	<dependencies>	

--- a/sample-apps/appsensor-ws-rest-server-boot/Dockerfile
+++ b/sample-apps/appsensor-ws-rest-server-boot/Dockerfile
@@ -1,0 +1,5 @@
+FROM java:8
+VOLUME /tmp
+ADD target/appsensor-ws-rest-server-boot-0.0.1-SNAPSHOT.jar app.jar
+RUN bash -c 'touch /app.jar'
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]

--- a/sample-apps/appsensor-ws-rest-server-boot/README.md
+++ b/sample-apps/appsensor-ws-rest-server-boot/README.md
@@ -8,7 +8,9 @@ Once you've built AppSensor's modules there are three ways to run the WS REST Se
 Spring Boot
 ------------
 This will run the application locally 'exploded' allowing static resource to be 'hot reloaded'
-`mvn spring-boot:run`
+```
+mvn spring-boot:run
+```
 
 
 Fat Jar

--- a/sample-apps/appsensor-ws-rest-server-boot/README.md
+++ b/sample-apps/appsensor-ws-rest-server-boot/README.md
@@ -1,0 +1,28 @@
+AppSensor WS REST Server 
+==========
+
+Before running you must first build AppSensor's modules, follow the directions in README in the project root.
+
+Once you've built AppSensor's modules there are three ways to run the WS REST Server
+
+Spring Boot
+------------
+This will run the application locally 'exploded' allowing static resource to be 'hot reloaded'
+`mvn spring-boot:run`
+
+
+Fat Jar
+------------
+This will build a jar that can be transported and run on any Java 8 host
+```
+mvn package
+java -jar target/appsensor-ws-rest-server-boot-0.0.1-SNAPSHOT.jar
+```
+
+Docker
+-----------
+```
+mvn package 
+sudo docker build -t appsensor-ws-rest-server-boot . 
+sudo docker run -d -p 8085:8085 appsensor-ws-rest-server-boot
+```

--- a/sample-apps/appsensor-ws-rest-server-boot/README.md
+++ b/sample-apps/appsensor-ws-rest-server-boot/README.md
@@ -24,7 +24,6 @@ java -jar target/appsensor-ws-rest-server-boot-0.0.1-SNAPSHOT.jar
 Docker
 -----------
 ```
-mvn package 
-sudo docker build -t appsensor-ws-rest-server-boot . 
-sudo docker run -d -p 8085:8085 appsensor-ws-rest-server-boot
+mvn package docker:build
+docker run -d -p 8085:8085 appsensor/appsensor-ws-rest-server-boot 
 ```

--- a/sample-apps/appsensor-ws-rest-server-boot/README.md
+++ b/sample-apps/appsensor-ws-rest-server-boot/README.md
@@ -23,6 +23,8 @@ java -jar target/appsensor-ws-rest-server-boot-0.0.1-SNAPSHOT.jar
 
 Docker
 -----------
+This container does not implement TLS and is intended for development. Please harden the image if you intend
+to run in a container in production.
 ```
 mvn package docker:build
 docker run -d -p 8085:8085 appsensor/appsensor-ws-rest-server-boot 

--- a/sample-apps/appsensor-ws-rest-server-boot/pom.xml
+++ b/sample-apps/appsensor-ws-rest-server-boot/pom.xml
@@ -22,6 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<appsensor.version>2.2.0</appsensor.version>
+		<docker.image.prefix>appsensor</docker.image.prefix>
 	</properties>
 
 	<dependencies>
@@ -145,6 +146,22 @@
                 			</requiresUnpack>
             			</configuration>
 			</plugin>
+			<plugin>
+            	<groupId>com.spotify</groupId>
+            	<artifactId>docker-maven-plugin</artifactId>
+            	<version>0.2.3</version>
+            	<configuration>
+                	<imageName>${docker.image.prefix}/${project.artifactId}</imageName>
+                	<dockerDirectory>.</dockerDirectory>
+                	<resources>
+                    	<resource>
+                        	<targetPath>/</targetPath>
+                        	<directory>${project.build.directory}</directory>
+                        	<include>${project.build.finalName}.jar</include>
+                    	</resource>
+                	</resources>
+            	</configuration>
+        	</plugin>
 		</plugins>
 	</build>
 

--- a/sample-apps/appsensor-ws-rest-server-boot/pom.xml
+++ b/sample-apps/appsensor-ws-rest-server-boot/pom.xml
@@ -108,6 +108,42 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+                			<requiresUnpack>
+                    				<dependency>
+                        				<groupId>org.owasp.appsensor</groupId>
+                        				<artifactId>appsensor-ws-rest-server</artifactId>
+                    				</dependency>
+						<dependency>
+                                                        <groupId>org.owasp.appsensor</groupId>
+                                                        <artifactId>appsensor-core</artifactId>
+                                                </dependency>
+						<dependency>
+                        				<groupId>org.owasp.appsensor</groupId>
+                        				<artifactId>appsensor-storage-in-memory</artifactId>
+                				</dependency>
+                				<dependency>
+                        				<groupId>org.owasp.appsensor</groupId>
+                        				<artifactId>appsensor-analysis-reference</artifactId>
+                				</dependency>
+                				<dependency>
+                        				<groupId>org.owasp.appsensor</groupId>
+                        				<artifactId>appsensor-reporting-simple-logging</artifactId>
+                				</dependency>
+                				<dependency>
+                        				<groupId>org.owasp.appsensor</groupId>
+                        				<artifactId>appsensor-access-control-reference</artifactId>
+                				</dependency>
+						<dependency>
+				                        <groupId>org.owasp.appsensor</groupId>
+                        				<artifactId>appsensor-configuration-stax</artifactId>
+                				</dependency>
+                				<dependency>
+                        				<groupId>org.springframework.boot</groupId>
+                        				<artifactId>spring-boot-starter-jersey</artifactId>
+                				</dependency>
+                			</requiresUnpack>
+            			</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/sample-apps/appsensor-ws-rest-server-boot/pom.xml
+++ b/sample-apps/appsensor-ws-rest-server-boot/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<appsensor.version>2.2.0-SNAPSHOT</appsensor.version>
+		<appsensor.version>2.2.0</appsensor.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
### Part of Issue https://github.com/jtmelton/appsensor/issues/26

#### Build bug-fixes
- [x]  influxdb integration removed from main pom to allow the build to finish. John advised that component is waiting on a bug-fix from the vendor.
- [x] for appsensor-ws-rest-server-boot appsensor version changed from 2.2.0-SNAPSHOT to 2.2.0 the snapshot had pom errors.
- [x] mvn package now expands dependent jars so the fat jar will work (requiresUnpack element)

#### Creates a build process for a docker container of sample application ws-rest-server-boot.

#### Adds readme to sample application ws-rest-server-boot with some build instructions
