### PR TITLE
Use toStringBuilder for KeyValuePair class for consistency with proje…

### DIFF
--- a/appsensor-core/src/main/java/org/owasp/appsensor/core/KeyValuePair.java
+++ b/appsensor-core/src/main/java/org/owasp/appsensor/core/KeyValuePair.java
@@ -7,6 +7,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 @Entity
 public class KeyValuePair implements Serializable {
  
@@ -76,9 +78,13 @@ public class KeyValuePair implements Serializable {
     	return false;
     }
 
-    @Override
-    public String toString() { 
-           return "(" + key + ", " + value + ")"; 
-    }
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this)
+				.append("id", id)
+				.append("key", key)
+				.append("value", value)
+				.toString();
+	}
 
 }

--- a/appsensor-core/src/test/java/org/owasp/appsensor/core/util/DateUtilsTest.java
+++ b/appsensor-core/src/test/java/org/owasp/appsensor/core/util/DateUtilsTest.java
@@ -1,0 +1,34 @@
+package org.owasp.appsensor.core.util;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DateUtilsTest {
+
+    @Test
+    public void testFromStringNotNull() throws Exception {
+        String rfc3339String = "2016-03-08T13:22:53.108Z";
+        DateTime expected = new DateTime(rfc3339String, DateTimeZone.UTC);
+        DateTime actual = DateUtils.fromString(rfc3339String);
+
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testFromStringNull() throws Exception {
+        DateTime actual = DateUtils.fromString(null);
+
+        Assert.assertNull(actual);
+
+    }
+
+    @Test(expected=java.lang.IllegalArgumentException.class)
+    public void testFromEmptyString() throws Exception {
+
+        DateUtils.fromString("");
+
+    }
+}


### PR DESCRIPTION
- Use toStringBuilder for KeyValuePair's toString() for consistency with all other classes' toString() method 
- Added unit test for DateUtils class