### PR TITLE
"FileBasedEventStorageCustomLocationTest" test not passed in Windows

### DIFF
--- a/storage-providers/appsensor-storage-file-based/src/test/java/org/owasp/appsensor/storage/file/FileBasedEventStorageCustomLocationTest.java
+++ b/storage-providers/appsensor-storage-file-based/src/test/java/org/owasp/appsensor/storage/file/FileBasedEventStorageCustomLocationTest.java
@@ -1,6 +1,8 @@
 package org.owasp.appsensor.storage.file;
 
 import javax.inject.Inject;
+import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -27,13 +29,16 @@ public class FileBasedEventStorageCustomLocationTest {
 	
 	@Test
 	public void deleteTestFiles() throws Exception {
+				
+		Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
+					
 		FileBasedEventStore eventStore = (FileBasedEventStore)appSensorServer.getEventStore();
 		FileBasedAttackStore attackStore = (FileBasedAttackStore)appSensorServer.getAttackStore();
 		FileBasedResponseStore responseStore = (FileBasedResponseStore)appSensorServer.getResponseStore();
-
-		Assert.assertEquals("/tmp/as_events.txt", eventStore.getPath().toString());
-		Assert.assertEquals("/tmp/as_attacks.txt", attackStore.getPath().toString());
-		Assert.assertEquals("/tmp/as_responses.txt", responseStore.getPath().toString());
+			
+		Assert.assertEquals(tempDir.resolve("as_events.txt").toString(), eventStore.getPath().toString());		
+		Assert.assertEquals(tempDir.resolve("as_attacks.txt").toString(), attackStore.getPath().toString());
+		Assert.assertEquals(tempDir.resolve("as_responses.txt").toString(), responseStore.getPath().toString());
 	}
 	
 }

--- a/storage-providers/appsensor-storage-file-based/src/test/resources/base-context-custom-files.xml
+++ b/storage-providers/appsensor-storage-file-based/src/test/resources/base-context-custom-files.xml
@@ -7,17 +7,17 @@ http://www.springframework.org/schema/context
 http://www.springframework.org/schema/context/spring-context-4.0.xsd">
 
     <bean class="org.owasp.appsensor.storage.file.FileBasedEventStore">
-	    <property name="filePath" value="/tmp"/>
+	    
 	    <property name="fileName" value="as_events.txt"/>
 	</bean>
 	
 	<bean class="org.owasp.appsensor.storage.file.FileBasedAttackStore">
-	    <property name="filePath" value="/tmp"/>
+	    
 	    <property name="fileName" value="as_attacks.txt"/>
 	</bean>
 	
 	<bean class="org.owasp.appsensor.storage.file.FileBasedResponseStore">
-	    <property name="filePath" value="/tmp"/>
+	    
 	    <property name="fileName" value="as_responses.txt"/>
 	</bean>
 


### PR DESCRIPTION
The current "FileBasedEventStorageCustomLocationTest " unit test uses "base-context-custom-files.xml" resource file as its application context. In the resource file the default TEMP directory assumed to be /tmp which is not compatible with Windows. 

To solve this, the corresponding property(filePath) setting in .xml file was removed and instead the temp directory was prepared in the test class.
This change passed all  tests: "mvn test"
