### PR TITLE
Adding the method to the resource object

### DIFF
--- a/appsensor-core/src/main/java/org/owasp/appsensor/core/Resource.java
+++ b/appsensor-core/src/main/java/org/owasp/appsensor/core/Resource.java
@@ -32,6 +32,13 @@ public class Resource implements IAppsensorEntity {
 	@Column
 	private String location;
 
+	/**
+	 * The method used to request the resource. In terms of HTTP this would be GET/POST/PUT/etc.
+	 * In the case, in which the resources specifices an object this could be the invoked object method.
+	 */
+	@Column
+	private String method;
+
 	@Override
 	public String getId() {
 		return id;
@@ -49,5 +56,12 @@ public class Resource implements IAppsensorEntity {
 	public void setLocation(String location) {
 		this.location = location;
 	}
-	
+
+	public String getMethod() {
+		return method;
+	}
+
+	public void setMethod(String method) {
+		this.method = method;
+	}
 }

--- a/appsensor-core/src/main/java/org/owasp/appsensor/core/Resource.java
+++ b/appsensor-core/src/main/java/org/owasp/appsensor/core/Resource.java
@@ -34,7 +34,7 @@ public class Resource implements IAppsensorEntity {
 
 	/**
 	 * The method used to request the resource. In terms of HTTP this would be GET/POST/PUT/etc.
-	 * In the case, in which the resources specifices an object this could be the invoked object method.
+	 * In the case, in which the resources specifies an object this could be the invoked object method.
 	 */
 	@Column
 	private String method;


### PR DESCRIPTION
This PR adds the method used to access a resource. In terms of HTTP this would be GET/POST/PUT/etc. In the case, in which the resources specifies an object this could be the invoked object method.

I furthermore modified the ReferenceStatisticalEngineTest to use completely filled event objects. This way, potential persistence problems could be detected.

@jtmelton Please consider this PR as a suggestion. I'm curious whether or not you find it appropriate to add an attribute for "method". 