### PR TITLE
Fixed bug to find proper earliest time for collecting events

### DIFF
--- a/analysis-engines/appsensor-analysis-rules/src/main/java/org/owasp/appsensor/analysis/AggregateEventAnalysisEngine.java
+++ b/analysis-engines/appsensor-analysis-rules/src/main/java/org/owasp/appsensor/analysis/AggregateEventAnalysisEngine.java
@@ -274,9 +274,13 @@ public class AggregateEventAnalysisEngine extends EventAnalysisEngine {
 	protected ArrayList<Event> getApplicableEvents(Event triggerEvent, Rule rule) {
 		ArrayList<Event> events = new ArrayList<Event>();
 
+		DateTime ruleStartTime = DateUtils.fromString(triggerEvent.getTimestamp()).minus(rule.getWindow().toMillis());
+		DateTime lastAttackTime = findMostRecentAttackTime(triggerEvent, rule);
+		DateTime earliest = ruleStartTime.isAfter(lastAttackTime) ? ruleStartTime : lastAttackTime;
+
 		SearchCriteria criteria = new SearchCriteria().
 				setUser(triggerEvent.getUser()).
-				setEarliest(findMostRecentAttackTime(triggerEvent, rule).plus(1).toString()).
+				setEarliest(earliest.plus(1).toString()).
 				setRule(rule).
 				setDetectionSystemIds(appSensorServer.getConfiguration().getRelatedDetectionSystems(triggerEvent.getDetectionSystem()));
 

--- a/execution-modes/appsensor-local/src/test/java/org/owasp/appsensor/local/analysis/AggregateEventAnalysisEngineIntegrationTest.java
+++ b/execution-modes/appsensor-local/src/test/java/org/owasp/appsensor/local/analysis/AggregateEventAnalysisEngineIntegrationTest.java
@@ -510,6 +510,40 @@ public class AggregateEventAnalysisEngineIntegrationTest {
 		assertEquals(2, appSensorServer.getAttackStore().findAttacks(ruleCriteria).size());
 	}
 
+	// test the earliest attack bug
+		@Test
+		public void test8_DP1() throws Exception {
+			DateTime time = DateUtils.epoch().plusHours(100);
+			SearchCriteria ruleCriteria = new SearchCriteria().
+				setUser(bob).
+				setRule(rules.get(0)).
+				setDetectionSystemIds(detectionSystems1);
+
+			setRule(appSensorServer, rules.get(0));
+
+			addEvent(detectionPoint1, time);
+			addEvent(detectionPoint1, time.plusMinutes(1));
+			addEvent(detectionPoint1, time.plusMinutes(2));
+
+			assertEquals(1, appSensorServer.getAttackStore().findAttacks(ruleCriteria).size());
+
+			addEvent(detectionPoint1, time.plusMinutes(3));
+			addEvent(detectionPoint1, time.plusMinutes(4));
+
+			assertEquals(1, appSensorServer.getAttackStore().findAttacks(ruleCriteria).size());
+
+			time = time.plusHours(1);
+
+			addEvent(detectionPoint1, time);
+
+			assertEquals(1, appSensorServer.getAttackStore().findAttacks(ruleCriteria).size());
+
+			addEvent(detectionPoint1, time.plusMinutes(1));
+			addEvent(detectionPoint1, time.plusMinutes(2));
+
+			assertEquals(2, appSensorServer.getAttackStore().findAttacks(ruleCriteria).size());
+		}
+
 	// this method doesn't actually wait, it just adds events with a predetermined time
 	// does not check anything
 	private void addEvent(DetectionPoint detectionPoint, DateTime time) {


### PR DESCRIPTION
Originally didn't check the rule window when gathering events and only used the last attack time. Now getting both last attack time and rule.window time before the trigger event, and using whichever occurred last.