### PR TITLE
Fixing influxdb Bug

### DIFF
--- a/storage-providers/appsensor-storage-influxdb/README.md
+++ b/storage-providers/appsensor-storage-influxdb/README.md
@@ -1,0 +1,4 @@
+influxdb
+=========
+
+AppSensor only supports versions of influxdb later than 0.8.

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/Utils.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/Utils.java
@@ -34,7 +34,7 @@ public class Utils {
   // fields / tags
   public static final String LABEL = "label";
   public static final String USERNAME = "username";
-  public static final String TIMESTAMP = "timestamp";
+  public static final String TIMESTAMP = "time";
   public static final String DETECTION_SYSTEM = "detectionSystem";
   public static final String CATEGORY = "category";
   public static final String THRESHOLD_COUNT = "thresholdCount";


### PR DESCRIPTION
The time field in the influxdb schema is now called 'time' instead of 'timestamp'. Changed since influxdb version 0.8.