### PR TITLE
rule integration with influxdb storage

### DIFF
--- a/execution-modes/appsensor-local/src/test/java/org/owasp/appsensor/local/analysis/SimpleAggregateEventAnalysisEngineTest.java
+++ b/execution-modes/appsensor-local/src/test/java/org/owasp/appsensor/local/analysis/SimpleAggregateEventAnalysisEngineTest.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 
 import javax.inject.Inject;
 
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -23,16 +25,20 @@ import org.owasp.appsensor.core.Response;
 import org.owasp.appsensor.core.Threshold;
 import org.owasp.appsensor.core.User;
 import org.owasp.appsensor.core.analysis.EventAnalysisEngine;
-import org.owasp.appsensor.core.configuration.server.ServerConfiguration;
 import org.owasp.appsensor.core.criteria.SearchCriteria;
 import org.owasp.appsensor.core.rule.Clause;
-import org.owasp.appsensor.core.rule.Rule;
 import org.owasp.appsensor.core.rule.MonitorPoint;
+import org.owasp.appsensor.core.rule.Rule;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
- * Basic test for the {@link AggregateEventAnalysisEngine}.
+ * Basic test for the {@link AggregateEventAnalysisEngine}. Built to be extended by other components
+ * to test integration with the rules engine.
+ *
+ * Tests should finish with the last event triggering an attack, so that each test can start
+ * assuming that only the events created in each test will count towards the attack threshold.
+ * todo: fix this by clearing events or adding time before each test
  *
  * @author David Scrobonia (davidscrobonia@gmail.com)
  * @author John Melton (jtmelton@gmail.com) http://www.jtmelton.com/
@@ -42,21 +48,23 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration(locations={"classpath:base-context.xml"})
 public class SimpleAggregateEventAnalysisEngineTest {
 
-	private static User bob = new User("bob");
+	protected static User bob = new User("bob");
 
-	private static DetectionPoint detectionPoint1 = new DetectionPoint();
+	protected static ArrayList<DetectionPoint> detectionPoints = null;
 
-	private static Collection<String> detectionSystems1 = new ArrayList<String>();
+	protected static Collection<String> detectionSystems1 = new ArrayList<String>();
 
-	private static DetectionSystem detectionSystem1 = new DetectionSystem("localhostme");
+	protected static DetectionSystem detectionSystem1 = new DetectionSystem("localhostme");
 
-	private static HashMap<String, SearchCriteria> criteria = new HashMap<String, SearchCriteria>();
+	protected static HashMap<String, SearchCriteria> criteria = new HashMap<String, SearchCriteria>();
 
-	private static AggregateEventAnalysisEngine myEngine = null;
+	protected static AggregateEventAnalysisEngine rulesEngine = null;
 
-	private static ArrayList<Rule> rules = null;
+	protected static ArrayList<Rule> rules = null;
 
-	protected int sleepAmount = 10;
+	protected static DateTime time;
+
+	protected static int SLEEP_AMOUNT = 10;
 
 	@Inject
 	AppSensorServer appSensorServer;
@@ -66,108 +74,107 @@ public class SimpleAggregateEventAnalysisEngineTest {
 
 	@BeforeClass
 	public static void doSetup() {
-		detectionPoint1.setCategory(DetectionPoint.Category.INPUT_VALIDATION);
-		detectionPoint1.setLabel("IE1");
+		// instantiate member variables
 
 		detectionSystems1.add(detectionSystem1.getDetectionSystemId());
+
+		detectionPoints = generateDetectionPoints();
+
+		rules = generateRules();
 
 		criteria.put("all", new SearchCriteria().setDetectionSystemIds(detectionSystems1));
 
 		criteria.put("dp1", new SearchCriteria().
-				setUser(bob).
-				setDetectionPoint(detectionPoint1).
+				setDetectionPoint(new DetectionPoint(DetectionPoint.Category.INPUT_VALIDATION, "IE1")).
 				setDetectionSystemIds(detectionSystems1));
 
-		rules = generateRules();
 
 		criteria.put("rule1", new SearchCriteria().
-				setUser(bob).
 				setRule(rules.get(0)).
 				setDetectionSystemIds(detectionSystems1));
+
+		time = DateTime.now().minusMinutes(2).toDateTime(DateTimeZone.UTC);
 	}
 
 	@Before
 	public void initializeTest() {
-		if (myEngine == null) {
-			initialSetup();
-		}
+		rulesEngine = getRulesEngine();
 
-		// clear rules
-		setRule(appSensorServer, null);
-	}
+		// clear any existing rules & detection points
+		ArrayList<Rule> emptyRules = new ArrayList<Rule>();
+		appSensorServer.getConfiguration().setRules(emptyRules);
 
-	public void initialSetup() {
-		//instantiate server
-		ServerConfiguration updatedConfiguration = appSensorServer.getConfiguration();
-		updatedConfiguration.setDetectionPoints(loadMockedDetectionPoints());
-		appSensorServer.setConfiguration(updatedConfiguration);
-
-		Collection<EventAnalysisEngine> engines = appSensorServer.getEventAnalysisEngines();
-
-		for (EventAnalysisEngine engine : engines) {
-			if (engine instanceof AggregateEventAnalysisEngine){
-				myEngine = (AggregateEventAnalysisEngine)engine;
-			}
-		}
-
-		setRule(appSensorServer, null);
+		ArrayList<DetectionPoint> emptyDps = new ArrayList<DetectionPoint>();
+		appSensorServer.getConfiguration().setDetectionPoints(emptyDps);
 	}
 
 	@Test
 	public void test1_DP1() throws Exception {
-		//Add rule
-		setRule(appSensorServer, rules.get(0));
+		// add rules/detection points
+		ArrayList<Rule> rulesToAdd = new ArrayList<Rule>();
+		rulesToAdd.add(rules.get(0));
+		appSensorServer.getConfiguration().setRules(rulesToAdd);
 
-		//is empty
-		assertEventsAndAttacks(0, 0, criteria.get("all"));
+		// add detection point
+		ArrayList<DetectionPoint> dpsToAdd = new ArrayList<DetectionPoint>();
+		dpsToAdd.add(detectionPoints.get(0));
+		appSensorServer.getConfiguration().setDetectionPoints(dpsToAdd);
+
+		DetectionPoint detectionPoint1 = detectionPoints.get(0);
+
+		// get events and attacks
+		int numEvents = appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size();
+		int numDPAttacks = appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size();
+		int numRuleAttacks = appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size();
+
+		// useless sanity check
+		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+
 
 		// 3 events and triggered attack
-		generateEvents(sleepAmount*3, detectionPoint1, 3, "rule1");
-		assertEventsAndAttacks(3, 1, criteria.get("dp1"));
-		assertEquals(1, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+		addEvents(bob, detectionPoint1, 3);
+		numEvents += 3; numDPAttacks++; numRuleAttacks++;
+
+		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
 
 		// 1 event and no new attack
-		generateEvents(sleepAmount, detectionPoint1, 1, "rule1");
-		assertEventsAndAttacks(4, 1, criteria.get("dp1"));
-		assertEquals(1, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+		addEvent(bob, detectionPoint1);
+		numEvents += 1;
+
+		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
 
 		// 2 events and 2 total attack
-		generateEvents(sleepAmount*2, detectionPoint1, 2, "rule1");
-		assertEventsAndAttacks(6, 2, criteria.get("dp1"));
-		assertEquals(2, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+		addEvents(bob, detectionPoint1, 2);
+		numEvents += 2; numDPAttacks++; numRuleAttacks++;
+
+		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
 	}
 
-	//assumes no rules will be triggered until last event
-	private void generateEvents (int time, DetectionPoint detectionPoint, int eventCount, String ruleName) throws Exception {
-		int attackCount = appSensorServer.getAttackStore().findAttacks(criteria.get(ruleName)).size();
+	protected void addEvent(User user, DetectionPoint detectionPoint) {
+		appSensorClient.getEventManager().addEvent(new Event(user, detectionPoint, time.toString(), detectionSystem1));
+		time = time.plusMillis(SLEEP_AMOUNT);
 
-		for (int i = 0; i < eventCount; i++) {
-			assertEquals(attackCount, appSensorServer.getAttackStore().findAttacks(criteria.get(ruleName)).size());
-			appSensorClient.getEventManager().addEvent(new Event(bob, detectionPoint, new DetectionSystem("localhostme")));
-			Thread.sleep(time/eventCount);
+	}
+
+	protected void addEvents(User user, DetectionPoint detectionPoint, int count) {
+		for (int i=0; i<count; i++) {
+			appSensorClient.getEventManager().addEvent(new Event(user, detectionPoint, time.toString(), detectionSystem1));
+			time = time.plusMillis(SLEEP_AMOUNT);
 		}
-	}
-
-	private void assertEventsAndAttacks (int eventCount, int attackCount, SearchCriteria criteria) {
-		if (criteria.getRule() == null) {
-			assertEquals(eventCount, appSensorServer.getEventStore().findEvents(criteria).size());
-		}
-		assertEquals(attackCount, appSensorServer.getAttackStore().findAttacks(criteria).size());
-	}
-
-	private void setRule(AppSensorServer server, Rule rule) {
-		Collection<Rule> rules = new ArrayList<Rule>();
-		rules.add(rule);
-		ServerConfiguration updatedConfiguration = appSensorServer.getConfiguration();
-		updatedConfiguration.setRules(rules);
-		appSensorServer.setConfiguration(updatedConfiguration);
 	}
 
 	private static ArrayList<Rule> generateRules() {
 		final ArrayList<Rule> configuredRules = new ArrayList<Rule>();
 		// intervals
 		Interval minutes5 = new Interval(5, Interval.MINUTES);
-		Interval minutes16 = new Interval(16, Interval.MINUTES);
 
 		// detection points
 		MonitorPoint point1 = new MonitorPoint(new DetectionPoint(DetectionPoint.Category.INPUT_VALIDATION, "IE1", new Threshold(3, minutes5)));
@@ -182,7 +189,7 @@ public class SimpleAggregateEventAnalysisEngineTest {
 		// responses
 		ArrayList<Response> responses = generateResponses();
 
-		//rule 1: DP1
+		// rule 1: DP1
 		ArrayList<Clause> clauses1 = new ArrayList<Clause>();
 		clauses1.add(clause1);
 
@@ -191,25 +198,25 @@ public class SimpleAggregateEventAnalysisEngineTest {
 		ArrayList<org.owasp.appsensor.core.rule.Expression> expressions1 = new ArrayList<org.owasp.appsensor.core.rule.Expression>();
 		expressions1.add(expression1);
 
-		configuredRules.add(new Rule("00000000-0000-0000-0000-000000000011", minutes16, expressions1, responses, "Rule 1"));
+		configuredRules.add(new Rule("00000000-0000-0000-0000-000000000011", minutes5, expressions1, responses, "Rule 1"));
 
 		return configuredRules;
 	}
 
-	private static Collection<DetectionPoint> loadMockedDetectionPoints() {
-		final Collection<DetectionPoint> configuredDetectionPoints = new ArrayList<DetectionPoint>();
+	private static ArrayList<DetectionPoint> generateDetectionPoints() {
+		ArrayList<DetectionPoint> detectionPoints = new ArrayList<DetectionPoint>();
 
-		ArrayList<Response> responses = generateResponses();
+		// dp1: 3 events in 5 minutes
+		DetectionPoint detectionPoint1 = new DetectionPoint();
 
-		Interval minutes5 = new Interval(5, Interval.MINUTES);
+		detectionPoint1.setCategory(DetectionPoint.Category.INPUT_VALIDATION);
+		detectionPoint1.setLabel("IE1");
+		detectionPoint1.setThreshold(new Threshold(3, new Interval(5, Interval.MINUTES)));
+		detectionPoint1.setResponses(generateResponses());
 
-		Threshold events3minutes5 = new Threshold(3, minutes5);
+		detectionPoints.add(detectionPoint1);
 
-		DetectionPoint point1 = new DetectionPoint(DetectionPoint.Category.INPUT_VALIDATION, "IE1", events3minutes5, responses);
-
-		configuredDetectionPoints.add(point1);
-
-		return configuredDetectionPoints;
+		return detectionPoints;
 	}
 
 	private static ArrayList<Response> generateResponses() {
@@ -242,4 +249,15 @@ public class SimpleAggregateEventAnalysisEngineTest {
 		return responses;
 	}
 
+	public AggregateEventAnalysisEngine getRulesEngine() {
+		Collection<EventAnalysisEngine> engines = appSensorServer.getEventAnalysisEngines();
+
+		for (EventAnalysisEngine engine : engines) {
+			if (engine instanceof AggregateEventAnalysisEngine){
+				return (AggregateEventAnalysisEngine)engine;
+			}
+		}
+
+		return null;
+	}
 }

--- a/storage-providers/appsensor-storage-influxdb/pom.xml
+++ b/storage-providers/appsensor-storage-influxdb/pom.xml
@@ -50,6 +50,13 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.owasp.appsensor</groupId>
+			<artifactId>appsensor-analysis-rules</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.owasp.appsensor</groupId>
@@ -91,5 +98,5 @@
 	  	<artifactId>appsensor-parent</artifactId>
 		<version>2.3.2</version>
 	</parent>
-	
+
 </project>

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbAttackStore.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbAttackStore.java
@@ -98,7 +98,7 @@ public class InfluxDbAttackStore extends AttackStore {
     Collection<String> detectionSystemIds = criteria.getDetectionSystemIds();
     DateTime earliest = DateUtils.fromString(criteria.getEarliest());
 
-    String influxQL = Utils.constructInfluxQL(Utils.ATTACKS, user, detectionPoint, rule, detectionSystemIds, earliest, Utils.QueryMode.CONSIDER_DETECTION_POINT_OR_RULE);
+    String influxQL = Utils.constructInfluxQL(Utils.ATTACKS, user, detectionPoint, rule, detectionSystemIds, earliest, Utils.QueryMode.CONSIDER_THRESHOLDS);
     Query query = new Query(influxQL, Utils.DATABASE);
 
     QueryResult results = influxDB.query(query);

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbAttackStore.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbAttackStore.java
@@ -1,34 +1,34 @@
 package org.owasp.appsensor.storage.influxdb;
 
-import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
-
-import org.influxdb.InfluxDB;
-import org.influxdb.InfluxDBFactory;
-import org.influxdb.dto.Point;
-import org.influxdb.dto.Query;
-import org.influxdb.dto.QueryResult;
-import org.joda.time.DateTime;
-import org.owasp.appsensor.core.Attack;
-import org.owasp.appsensor.core.DetectionPoint;
-import org.owasp.appsensor.core.Event;
-import org.owasp.appsensor.core.User;
-import org.owasp.appsensor.core.criteria.SearchCriteria;
-import org.owasp.appsensor.core.logging.Loggable;
-import org.owasp.appsensor.core.storage.AttackStore;
-import org.owasp.appsensor.core.util.DateUtils;
-import org.slf4j.Logger;
-import org.springframework.core.env.Environment;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Named;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Point.Builder;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.joda.time.DateTime;
+import org.owasp.appsensor.core.Attack;
+import org.owasp.appsensor.core.DetectionPoint;
+import org.owasp.appsensor.core.User;
+import org.owasp.appsensor.core.criteria.SearchCriteria;
+import org.owasp.appsensor.core.logging.Loggable;
+import org.owasp.appsensor.core.rule.Rule;
+import org.owasp.appsensor.core.storage.AttackStore;
+import org.owasp.appsensor.core.util.DateUtils;
+import org.slf4j.Logger;
+import org.springframework.core.env.Environment;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
 
 /**
  * Created by john.melton on 3/10/16.
@@ -53,24 +53,36 @@ public class InfluxDbAttackStore extends AttackStore {
    */
   @Override
   public void addAttack(Attack attack) {
-    logger.warn("Security attack " + attack.getDetectionPoint().getLabel() + " triggered by user: " + attack.getUser().getUsername());
+    logger.warn("Security attack " + attack.getName() + " triggered by user: " + attack.getUser().getUsername());
 
-    Point point = Point.measurement(Utils.ATTACKS)
+    Builder builder = Point.measurement(Utils.ATTACKS)
         .time(DateUtils.fromString(attack.getTimestamp()).getMillis(), TimeUnit.MILLISECONDS)
-        .field(Utils.LABEL, attack.getDetectionPoint().getLabel())
         .tag(Utils.USERNAME, attack.getUser().getUsername())
         .tag(Utils.TIMESTAMP, attack.getTimestamp())
         .tag(Utils.DETECTION_SYSTEM, attack.getDetectionSystem().getDetectionSystemId())
-        .tag(Utils.CATEGORY, attack.getDetectionPoint().getCategory())
-        .tag(Utils.LABEL, attack.getDetectionPoint().getLabel())
-        .tag(Utils.THRESHOLD_COUNT, String.valueOf(attack.getDetectionPoint().getThreshold().getCount()))
-        .tag(Utils.THRESHOLD_INTERVAL_DURATION, String.valueOf( attack.getDetectionPoint().getThreshold().getInterval().getDuration() ) )
-        .tag(Utils.THRESHOLD_INTERVAL_UNIT, attack.getDetectionPoint().getThreshold().getInterval().getUnit())
-        .field(Utils.JSON_CONTENT, gson.toJson(attack))
-        .build();
+        .field(Utils.JSON_CONTENT, gson.toJson(attack));
+
+    if (attack.getDetectionPoint() != null) {
+	    builder
+		    .field(Utils.LABEL, attack.getDetectionPoint().getLabel())
+		    .tag(Utils.CATEGORY, attack.getDetectionPoint().getCategory())
+		    .tag(Utils.LABEL, attack.getDetectionPoint().getLabel())
+		    .tag(Utils.THRESHOLD_COUNT, String.valueOf(attack.getDetectionPoint().getThreshold().getCount()))
+		    .tag(Utils.THRESHOLD_INTERVAL_DURATION, String.valueOf( attack.getDetectionPoint().getThreshold().getInterval().getDuration() ) )
+		    .tag(Utils.THRESHOLD_INTERVAL_UNIT, attack.getDetectionPoint().getThreshold().getInterval().getUnit());
+    }
+
+    if (attack.getRule() != null) {
+    	builder
+    		.tag(Utils.RULE_GUID, attack.getRule().getGuid())
+    		.tag(Utils.RULE_NAME, attack.getRule().getName())
+    		.tag(Utils.RULE_WINDOW_DURATION, String.valueOf( attack.getRule().getWindow().getDuration()))
+    		.tag(Utils.RULE_WINDOW_UNIT, attack.getRule().getWindow().getUnit());
+    }
+
+    Point point = builder.build();
 
     influxDB.write(Utils.DATABASE, "default", point);
-
     super.notifyListeners(attack);
   }
 
@@ -82,11 +94,11 @@ public class InfluxDbAttackStore extends AttackStore {
 
     User user = criteria.getUser();
     DetectionPoint detectionPoint = criteria.getDetectionPoint();
+    Rule rule = criteria.getRule();
     Collection<String> detectionSystemIds = criteria.getDetectionSystemIds();
     DateTime earliest = DateUtils.fromString(criteria.getEarliest());
 
-    String influxQL = Utils.constructInfluxQL(Utils.ATTACKS, user, detectionPoint, detectionSystemIds, earliest, Utils.QueryMode.CONSIDER_DETECTION_POINT);
-
+    String influxQL = Utils.constructInfluxQL(Utils.ATTACKS, user, detectionPoint, rule, detectionSystemIds, earliest, Utils.QueryMode.CONSIDER_DETECTION_POINT_OR_RULE);
     Query query = new Query(influxQL, Utils.DATABASE);
 
     QueryResult results = influxDB.query(query);

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbEventStore.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbEventStore.java
@@ -1,10 +1,14 @@
 package org.owasp.appsensor.storage.influxdb;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Utf8;
-import com.google.gson.Gson;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang3.StringUtils;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.Point;
@@ -13,7 +17,6 @@ import org.influxdb.dto.QueryResult;
 import org.joda.time.DateTime;
 import org.owasp.appsensor.core.DetectionPoint;
 import org.owasp.appsensor.core.Event;
-import org.owasp.appsensor.core.Threshold;
 import org.owasp.appsensor.core.User;
 import org.owasp.appsensor.core.criteria.SearchCriteria;
 import org.owasp.appsensor.core.listener.EventListener;
@@ -24,14 +27,8 @@ import org.owasp.appsensor.core.util.DateUtils;
 import org.slf4j.Logger;
 import org.springframework.core.env.Environment;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import javax.inject.Named;
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
 
 /**
  * This is an influxdb implementation of the {@link EventStore}.

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbEventStore.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbEventStore.java
@@ -74,9 +74,6 @@ public class InfluxDbEventStore extends EventStore {
         .tag(Utils.DETECTION_SYSTEM, event.getDetectionSystem().getDetectionSystemId())
         .tag(Utils.CATEGORY, event.getDetectionPoint().getCategory())
         .tag(Utils.LABEL, event.getDetectionPoint().getLabel())
-        .tag(Utils.THRESHOLD_COUNT, String.valueOf(event.getDetectionPoint().getThreshold().getCount()))
-		.tag(Utils.THRESHOLD_INTERVAL_DURATION, String.valueOf( event.getDetectionPoint().getThreshold().getInterval().getDuration() ) )
-		.tag(Utils.THRESHOLD_INTERVAL_UNIT, event.getDetectionPoint().getThreshold().getInterval().getUnit())
         .field(Utils.JSON_CONTENT, gson.toJson(event))
         .build();
 
@@ -106,7 +103,7 @@ public class InfluxDbEventStore extends EventStore {
       detectionPoint, null,
       detectionSystemIds,
       earliest,
-      Utils.QueryMode.CONSIDER_DETECTION_POINT_OR_RULE);
+      Utils.QueryMode.IGNORE_THRESHOLDS);
 
     if (rule != null) {
       influxQL += " AND (";
@@ -116,7 +113,7 @@ public class InfluxDbEventStore extends EventStore {
         influxQL += (i == 0) ? "" : " OR ";
 
         influxQL += "(";
-        influxQL += Utils.constructDetectionPointSqlString(point);
+        influxQL += Utils.constructDetectionPointSqlString(point, Utils.QueryMode.IGNORE_THRESHOLDS);
         influxQL += ")";
 
         i++;

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbResponseStore.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbResponseStore.java
@@ -101,7 +101,7 @@ public class InfluxDbResponseStore extends ResponseStore {
     Collection<String> detectionSystemIds = criteria.getDetectionSystemIds();
     DateTime earliest = DateUtils.fromString(criteria.getEarliest());
 
-    String influxQL = Utils.constructInfluxQL(Utils.RESPONSES, user, detectionPoint, rule, detectionSystemIds, earliest, Utils.QueryMode.IGNORE_DETECTION_POINT_OR_RULE);
+    String influxQL = Utils.constructInfluxQL(Utils.RESPONSES, user, detectionPoint, rule, detectionSystemIds, earliest, Utils.QueryMode.CONSIDER_THRESHOLDS);
 
     Query query = new Query(influxQL, Utils.DATABASE);
 

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbResponseStore.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbResponseStore.java
@@ -1,7 +1,13 @@
 package org.owasp.appsensor.storage.influxdb;
 
-import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
@@ -9,11 +15,7 @@ import org.influxdb.dto.Point;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
 import org.joda.time.DateTime;
-import org.owasp.appsensor.core.Attack;
 import org.owasp.appsensor.core.DetectionPoint;
-import org.owasp.appsensor.core.DetectionSystem;
-import org.owasp.appsensor.core.Interval;
-import org.owasp.appsensor.core.KeyValuePair;
 import org.owasp.appsensor.core.Response;
 import org.owasp.appsensor.core.User;
 import org.owasp.appsensor.core.criteria.SearchCriteria;
@@ -24,21 +26,8 @@ import org.owasp.appsensor.core.util.DateUtils;
 import org.slf4j.Logger;
 import org.springframework.core.env.Environment;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
 
 /**
  * Created by john.melton on 3/10/16.

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbResponseStore.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/InfluxDbResponseStore.java
@@ -18,6 +18,7 @@ import org.owasp.appsensor.core.Response;
 import org.owasp.appsensor.core.User;
 import org.owasp.appsensor.core.criteria.SearchCriteria;
 import org.owasp.appsensor.core.logging.Loggable;
+import org.owasp.appsensor.core.rule.Rule;
 import org.owasp.appsensor.core.storage.ResponseStore;
 import org.owasp.appsensor.core.util.DateUtils;
 import org.slf4j.Logger;
@@ -96,10 +97,11 @@ public class InfluxDbResponseStore extends ResponseStore {
 
     User user = criteria.getUser();
     DetectionPoint detectionPoint = criteria.getDetectionPoint();
+    Rule rule = criteria.getRule();
     Collection<String> detectionSystemIds = criteria.getDetectionSystemIds();
     DateTime earliest = DateUtils.fromString(criteria.getEarliest());
 
-    String influxQL = Utils.constructInfluxQL(Utils.RESPONSES, user, detectionPoint, detectionSystemIds, earliest, Utils.QueryMode.IGNORE_DETECTION_POINT);
+    String influxQL = Utils.constructInfluxQL(Utils.RESPONSES, user, detectionPoint, rule, detectionSystemIds, earliest, Utils.QueryMode.IGNORE_DETECTION_POINT_OR_RULE);
 
     Query query = new Query(influxQL, Utils.DATABASE);
 
@@ -157,4 +159,3 @@ public class InfluxDbResponseStore extends ResponseStore {
   }
 
 }
-

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/Utils.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/Utils.java
@@ -1,23 +1,19 @@
 package org.owasp.appsensor.storage.influxdb;
 
-import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.influxdb.InfluxDB;
-import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.QueryResult;
 import org.joda.time.DateTime;
 import org.owasp.appsensor.core.DetectionPoint;
 import org.owasp.appsensor.core.User;
 import org.owasp.appsensor.core.rule.Rule;
-import org.owasp.appsensor.core.util.DateUtils;
 import org.springframework.core.env.Environment;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import javax.annotation.PostConstruct;
+import com.google.common.base.Preconditions;
 
 /**
  * Created by john.melton on 3/11/16.

--- a/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/Utils.java
+++ b/storage-providers/appsensor-storage-influxdb/src/main/java/org/owasp/appsensor/storage/influxdb/Utils.java
@@ -56,7 +56,7 @@ public class Utils {
   public static final String INFLUXDB_PASSWORD = "APPSENSOR_INFLUXDB_PASSWORD";
 
   // query mode, whether or not to look for detection point related search criteria
-  public enum QueryMode {IGNORE_DETECTION_POINT_OR_RULE, CONSIDER_DETECTION_POINT_OR_RULE}
+  public enum QueryMode {IGNORE_THRESHOLDS, CONSIDER_THRESHOLDS}
 
   public synchronized static void createDatabaseIfNotExists(InfluxDB influxDB) {
     Preconditions.checkNotNull(influxDB, "InfluxDB reference must not be null");
@@ -99,14 +99,12 @@ public class Utils {
       clauses.add(Utils.DETECTION_SYSTEM + " = '" + detectionSystemIds.iterator().next() + "'");
     }
 
-    if(QueryMode.CONSIDER_DETECTION_POINT_OR_RULE == queryMode) {
-      if (detectionPoint != null) {
-        clauses.add(constructDetectionPointSqlString(detectionPoint));
-      }
+	if (detectionPoint != null) {
+		clauses.add(constructDetectionPointSqlString(detectionPoint, queryMode));
+	}
 
-      if (rule != null) {
-	     clauses.addAll(constructRuleSqlClauses(rule));
-      }
+    if (rule != null) {
+    	clauses.addAll(constructRuleSqlClauses(rule));
     }
 
     if(earliest != null) {
@@ -127,7 +125,7 @@ public class Utils {
     return sql;
   }
 
-  protected static String constructDetectionPointSqlString(DetectionPoint detectionPoint) {
+  protected static String constructDetectionPointSqlString(DetectionPoint detectionPoint, QueryMode mode) {
     List<String> clauses = new ArrayList<>();
     String sql = "";
 
@@ -139,18 +137,20 @@ public class Utils {
       clauses.add(Utils.LABEL + " = '" + detectionPoint.getLabel() + "'");
     }
 
-    if (detectionPoint.getThreshold() != null) {
-      clauses.add(Utils.THRESHOLD_COUNT + " = '" + detectionPoint.getThreshold().getCount() + "'");
+    if (QueryMode.CONSIDER_THRESHOLDS == mode) {
+	    if (detectionPoint.getThreshold() != null) {
+	      clauses.add(Utils.THRESHOLD_COUNT + " = '" + detectionPoint.getThreshold().getCount() + "'");
 
-      if (detectionPoint.getThreshold().getInterval() != null) {
-        clauses.add(
-            Utils.THRESHOLD_INTERVAL_DURATION + " = '" + detectionPoint.getThreshold().getInterval().getDuration() + "'");
+	      if (detectionPoint.getThreshold().getInterval() != null) {
+	        clauses.add(
+	            Utils.THRESHOLD_INTERVAL_DURATION + " = '" + detectionPoint.getThreshold().getInterval().getDuration() + "'");
 
-        if (detectionPoint.getThreshold().getInterval().getUnit() != null) {
-          clauses
-              .add(Utils.THRESHOLD_INTERVAL_UNIT + " = '" + detectionPoint.getThreshold().getInterval().getUnit() + "'");
-        }
-      }
+	        if (detectionPoint.getThreshold().getInterval().getUnit() != null) {
+	          clauses
+	              .add(Utils.THRESHOLD_INTERVAL_UNIT + " = '" + detectionPoint.getThreshold().getInterval().getUnit() + "'");
+	        }
+	      }
+	    }
     }
 
     int i = 0;

--- a/storage-providers/appsensor-storage-influxdb/src/test/java/org/owasp/appsensor/storage/influxdb/InfluxDbEventStorageWithRulesTest.java
+++ b/storage-providers/appsensor-storage-influxdb/src/test/java/org/owasp/appsensor/storage/influxdb/InfluxDbEventStorageWithRulesTest.java
@@ -1,0 +1,109 @@
+package org.owasp.appsensor.storage.influxdb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.owasp.appsensor.core.AppSensorClient;
+import org.owasp.appsensor.core.AppSensorServer;
+import org.owasp.appsensor.core.DetectionPoint;
+import org.owasp.appsensor.core.rule.Rule;
+import org.owasp.appsensor.local.analysis.SimpleAggregateEventAnalysisEngineTest;
+import org.springframework.core.env.Environment;
+
+/**
+ * Test basic InfluxDb based * Store's by extending the ReferenceStatisticalEventAnalysisEngineTest
+ * and only doing the file based setup. All of the same tests execute, but with the InfluxDb
+ * based stores instead of the memory based stores.
+ *
+ * @author John Melton (jtmelton@gmail.com) http://www.jtmelton.com/
+ */
+public class InfluxDbEventStorageWithRulesTest extends SimpleAggregateEventAnalysisEngineTest {
+
+	@Inject
+	Environment environment;
+
+	@Inject
+	AppSensorServer appSensorServer;
+
+	@Inject
+	AppSensorClient appSensorClient;
+
+    @Before
+    public void checkInitialization() {
+    	Assume.assumeTrue(isInitializedProperly());
+    }
+
+    @Test
+    public void testAttackCreation() throws Exception {
+    	if(! isInitializedProperly()) {
+    		System.err.println("Test not running because environment variables are not setup properly.");
+    	} else {
+    		// add rules/detection points
+    		ArrayList<Rule> rulesToAdd = new ArrayList<Rule>();
+    		rulesToAdd.add(rules.get(0));
+    		appSensorServer.getConfiguration().setRules(rulesToAdd);
+
+    		// add detection point
+    		ArrayList<DetectionPoint> dpsToAdd = new ArrayList<DetectionPoint>();
+    		dpsToAdd.add(detectionPoints.get(0));
+    		appSensorServer.getConfiguration().setDetectionPoints(dpsToAdd);
+
+    		DetectionPoint detectionPoint1 = detectionPoints.get(0);
+
+    		// get events and attacks
+    		int numEvents = appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size();
+    		int numDPAttacks = appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size();
+    		int numRuleAttacks = appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size();
+
+    		// useless sanity check
+    		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+    		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+    		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+
+    		// 1 event
+    		addEvent(bob, detectionPoint1);
+    		numEvents++;
+
+    		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+    		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+    		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+
+    		// 1 event
+    		addEvent(bob, detectionPoint1);
+    		numEvents++;
+
+    		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+    		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+    		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+
+    		// Attack triggered on 3rd event
+    		addEvent(bob, detectionPoint1);
+    		numEvents++; numDPAttacks++; numRuleAttacks++;
+
+    		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+    		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+    		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+
+    		// 3 events and triggered attack on 6th event
+    		addEvents(bob, detectionPoint1, 3);
+    		numEvents += 3; numDPAttacks++; numRuleAttacks++;
+
+    		assertEquals(numEvents, appSensorServer.getEventStore().findEvents(criteria.get("dp1")).size());
+    		assertEquals(numDPAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("dp1")).size());
+    		assertEquals(numRuleAttacks, appSensorServer.getAttackStore().findAttacks(criteria.get("rule1")).size());
+    	}
+    }
+
+  private boolean isInitializedProperly() {
+    return StringUtils.isNotBlank(environment.getProperty(Utils.INFLUXDB_CONNECTION_STRING)) &&
+           StringUtils.isNotBlank(environment.getProperty(Utils.INFLUXDB_USERNAME)) &&
+           StringUtils.isNotBlank(environment.getProperty(Utils.INFLUXDB_PASSWORD));
+  }
+}


### PR DESCRIPTION
Modified the influxdb storage provider to support rules. Modified the base rules test (SimpleAggregateEventAnalysisEngineTest) and extended it to create a new test for influxdb compatibility.

Biggest changes include:
- modifying base rules test
- adding influxdb/rules test
- modifying influxdb query builder
