### PR TITLE
Fix an exception I was getting in appsensor-ui

### DIFF
--- a/appsensor-ui/src/main/resources/application.properties
+++ b/appsensor-ui/src/main/resources/application.properties
@@ -12,7 +12,7 @@
 server.port=8084
 logging.level.org.springframework: INFO
 logging.level.org.hibernate: INFO
-
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 #logging.level.org.hibernate.SQL=DEBUG
 #logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 


### PR DESCRIPTION
I have followed the instructions [here](https://github.com/jtmelton/appsensor/blob/master/sample-apps/DemoSetup.md) to setup the demo of AppSensor.

I was getting an error along the lines of "Access to DialectResolutionInfo cannot be null when 'hibernate.dialect' not set".

Based on Internet research, adding this line to application.options seems to fix this issue although I have no idea if it would have any other unintended side effects.

As discussed in issue #87 I have another problem now although I don't think this particular change caused that issue.