### PR TITLE
Fix docker compose example

### DIFF
--- a/appsensor-ui/Dockerfile
+++ b/appsensor-ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM anapsix/alpine-java
 
 VOLUME /tmp
-ADD target/appsensor-ui-2.3.0.jar app.jar
+ADD target/appsensor-ui-2.3.2.jar app.jar
 
 ENV DOCKERIZE_VERSION="0.2.0"
 ENV DOCKERIZE_URL="https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION"

--- a/sample-apps/docker-compose-examples/getting-started/docker-compose.yml
+++ b/sample-apps/docker-compose-examples/getting-started/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services: 
   db:
-    image: mysql:latest
+    image: mysql:5
     container_name: db
     ports: 
       - "3306:3306"


### PR DESCRIPTION
The docker-compose example does not work straight out of the box. I seems that mysql:latest (8) does not work well with the application. Setting docker-image to mysql:5 seems to do the trick.

Also, Dockerfile in appsensor-ui referenced the wrong version of the artifact in target.